### PR TITLE
Change some perms for helpers

### DIFF
--- a/cogs/commands/info/help.py
+++ b/cogs/commands/info/help.py
@@ -7,7 +7,7 @@ from discord.ext.commands import Command, Group
 from setuptools import Command
 from data.services.guild_service import guild_service
 from utils import cfg, GIRContext, transform_context
-from utils.framework import whisper, gatekeeper
+from utils.framework import whisper, gatekeeper, whisper_helper
 from utils.views import command_list_autocomplete
 
 # TODO: This whole thing needs work
@@ -113,7 +113,7 @@ class Utilities(commands.Cog):
     @app_commands.describe(command_name="The name of the command to get info of")
     @app_commands.autocomplete(command_name=command_list_autocomplete)
     @transform_context
-    @whisper
+    @whisper_helper
     async def usage(self, ctx: GIRContext, command_name: str):
         command_arg_split = command_name.split()
         if len(command_arg_split) > 1:

--- a/cogs/commands/info/stats.py
+++ b/cogs/commands/info/stats.py
@@ -10,7 +10,7 @@ from discord import app_commands
 from discord.ext import commands
 from discord.utils import format_dt
 from utils import GIRContext, cfg, transform_context, format_number
-from utils.framework import mod_and_up, whisper
+from utils.framework import mod_and_up, whisper, whisper_helper
 
 
 class Stats(commands.Cog):
@@ -21,7 +21,7 @@ class Stats(commands.Cog):
     @app_commands.guilds(cfg.guild_id)
     @app_commands.command(description="Test server latency by measuring how long it takes to edit a message")
     @transform_context
-    @whisper
+    @whisper_helper
     async def ping(self, ctx: GIRContext) -> None:
         embed = discord.Embed(
             title="Pong!", color=discord.Color.blurple())
@@ -45,7 +45,7 @@ class Stats(commands.Cog):
     @app_commands.command(description="Get number of users of a role")
     @app_commands.describe(role="The role's ID")
     @transform_context
-    @whisper
+    @whisper_helper
     async def roleinfo(self, ctx: GIRContext, role: discord.Role) -> None:
         embed = discord.Embed(title="Role Statistics")
         embed.description = f"{len(role.members)} members have role {role.mention}"
@@ -103,7 +103,7 @@ class Stats(commands.Cog):
     @app_commands.guilds(cfg.guild_id)
     @app_commands.command(description="Present statistics on who has been banned for raids.")
     @transform_context
-    @whisper
+    @whisper_helper
     async def raidstats(self, ctx: GIRContext) -> None:
         embed = discord.Embed(title="Raid Statistics",
                               color=discord.Color.blurple())

--- a/cogs/commands/info/stats.py
+++ b/cogs/commands/info/stats.py
@@ -21,7 +21,7 @@ class Stats(commands.Cog):
     @app_commands.guilds(cfg.guild_id)
     @app_commands.command(description="Test server latency by measuring how long it takes to edit a message")
     @transform_context
-    @whisper_helper
+    @whisper
     async def ping(self, ctx: GIRContext) -> None:
         embed = discord.Embed(
             title="Pong!", color=discord.Color.blurple())
@@ -45,7 +45,7 @@ class Stats(commands.Cog):
     @app_commands.command(description="Get number of users of a role")
     @app_commands.describe(role="The role's ID")
     @transform_context
-    @whisper_helper
+    @whisper
     async def roleinfo(self, ctx: GIRContext, role: discord.Role) -> None:
         embed = discord.Embed(title="Role Statistics")
         embed.description = f"{len(role.members)} members have role {role.mention}"
@@ -103,7 +103,7 @@ class Stats(commands.Cog):
     @app_commands.guilds(cfg.guild_id)
     @app_commands.command(description="Present statistics on who has been banned for raids.")
     @transform_context
-    @whisper_helper
+    @whisper
     async def raidstats(self, ctx: GIRContext) -> None:
         embed = discord.Embed(title="Raid Statistics",
                               color=discord.Color.blurple())

--- a/cogs/commands/misc/ioscfw.py
+++ b/cogs/commands/misc/ioscfw.py
@@ -353,7 +353,6 @@ class iOSCFW(commands.Cog):
     @app_commands.describe(version="Version of iOS you want to jailbreak")
     @app_commands.autocomplete(version=ios_on_device_autocomplete)
     @transform_context
-    @whisper
     async def canijailbreak(self, ctx: GIRContext, device: DeviceTransformer, version: VersionOnDevice) -> None:
         response = await get_ios_cfw()
         found_jbs = []

--- a/cogs/commands/misc/memes.py
+++ b/cogs/commands/misc/memes.py
@@ -95,7 +95,7 @@ class Memes(commands.Cog):
     memes = app_commands.Group(
         name="memes", description="Interact with memes", guild_ids=[cfg.guild_id])
 
-    @mod_and_up()
+    @genius_or_submod_and_up()
     @memes.command(description="Add a new meme")
     @app_commands.describe(name="Name of the meme")
     @app_commands.describe(image="Image to show in embed")
@@ -148,7 +148,7 @@ class Memes(commands.Cog):
 
         await ctx.respond(f"Added new meme!", file=_file or discord.utils.MISSING, embed=await self.prepare_meme_embed(meme))
 
-    @mod_and_up()
+    @genius_or_submod_and_up()
     @memes.command(description="Edit an existing meme")
     @app_commands.describe(name="Name of the meme")
     @app_commands.autocomplete(name=memes_autocomplete)
@@ -202,7 +202,7 @@ class Memes(commands.Cog):
 
         await ctx.respond(f"Meme edited!", file=_file or discord.utils.MISSING, embed=await self.prepare_meme_embed(meme))
 
-    @mod_and_up()
+    @genius_or_submod_and_up()
     @memes.command(description="Delete a meme")
     @app_commands.describe(name="Name of the meme")
     @app_commands.autocomplete(name=memes_autocomplete)
@@ -254,7 +254,7 @@ class Memes(commands.Cog):
         responses = ["As I see it, yes.", "Ask again later.", "Better not tell you now.", "Cannot predict now.", "Concentrate and ask again.",
                      "Don’t count on it.", "It is certain.", "It is decidedly so.", "Most likely.", "My reply is no.", "My sources say no.",
                      "Outlook not so good.", "Outlook good.", "Reply hazy, try again.", "Signs point to yes.", "Very doubtful.", "Without a doubt.",
-                     "Yes.", "Yes – definitely.", "You may rely on it."]
+                     "Yes.", "Yes – definitely.", "You may rely on it.", "<:yes:1044717821399154840>"]
 
         response = random.choice(responses)
         embed = discord.Embed(color=discord.Color.blurple())

--- a/cogs/commands/misc/misc.py
+++ b/cogs/commands/misc/misc.py
@@ -217,7 +217,7 @@ class Misc(commands.Cog):
                               description=channel.topic, color=discord.Color.blue())
         await ctx.respond_or_edit(content=title, embed=embed)
 
-    @genius_and_up()
+    @mod_and_up()
     @app_commands.guilds(cfg.guild_id)
     @app_commands.command(description="Start a poll")
     @app_commands.describe(question="Question to ask")

--- a/cogs/commands/misc/misc.py
+++ b/cogs/commands/misc/misc.py
@@ -14,7 +14,7 @@ from PIL import Image
 from utils import (GIRContext, cfg, get_dstatus_components,
                    get_dstatus_incidents, transform_context)
 from utils.framework import (MONTH_MAPPING, Duration, gatekeeper,
-                             give_user_birthday_role, mod_and_up, whisper)
+                             give_user_birthday_role, mod_and_up, genius_and_up, whisper, whisper_helper)
 from utils.framework.transformers import ImageAttachment
 from utils.views import (PFPButton, PFPView, date_autocompleter,
                          rule_autocomplete)
@@ -39,7 +39,7 @@ class Misc(commands.Cog):
     @app_commands.describe(reminder="What do you want to be reminded of?")
     @app_commands.describe(duration="When do we remind you? (i.e 1m, 1h, 1d)")
     @transform_context
-    @whisper
+    @whisper_helper
     async def remindme(self, ctx: GIRContext, reminder: str, duration: Duration):
         now = datetime.datetime.now()
         delta = duration
@@ -217,7 +217,7 @@ class Misc(commands.Cog):
                               description=channel.topic, color=discord.Color.blue())
         await ctx.respond_or_edit(content=title, embed=embed)
 
-    @mod_and_up()
+    @genius_and_up()
     @app_commands.guilds(cfg.guild_id)
     @app_commands.command(description="Start a poll")
     @app_commands.describe(question="Question to ask")

--- a/cogs/commands/misc/misc.py
+++ b/cogs/commands/misc/misc.py
@@ -39,7 +39,7 @@ class Misc(commands.Cog):
     @app_commands.describe(reminder="What do you want to be reminded of?")
     @app_commands.describe(duration="When do we remind you? (i.e 1m, 1h, 1d)")
     @transform_context
-    @whisper_helper
+    @whisper
     async def remindme(self, ctx: GIRContext, reminder: str, duration: Duration):
         now = datetime.datetime.now()
         delta = duration

--- a/cogs/commands/misc/timezones.py
+++ b/cogs/commands/misc/timezones.py
@@ -61,7 +61,7 @@ class Timezones(commands.Cog):
     @app_commands.describe(zone="The timezone to set")
     @app_commands.autocomplete(zone=timezone_autocomplete)
     @transform_context
-    @whisper_helper
+    @whisper
     async def _set(self, ctx: GIRContext, zone: str):
         if zone not in pytz.common_timezones_set:
             raise commands.BadArgument("Timezone was not found!")
@@ -78,7 +78,7 @@ class Timezones(commands.Cog):
 
     @timezone.command(name="remove", description="Remove your timezone from the database")
     @transform_context
-    @whisper_helper
+    @whisper
     async def remove(self, ctx: GIRContext):
         db_user = user_service.get_user(ctx.author.id)
         db_user.timezone = None

--- a/cogs/commands/misc/timezones.py
+++ b/cogs/commands/misc/timezones.py
@@ -61,7 +61,7 @@ class Timezones(commands.Cog):
     @app_commands.describe(zone="The timezone to set")
     @app_commands.autocomplete(zone=timezone_autocomplete)
     @transform_context
-    @whisper
+    @whisper_helper
     async def _set(self, ctx: GIRContext, zone: str):
         if zone not in pytz.common_timezones_set:
             raise commands.BadArgument("Timezone was not found!")
@@ -78,7 +78,7 @@ class Timezones(commands.Cog):
 
     @timezone.command(name="remove", description="Remove your timezone from the database")
     @transform_context
-    @whisper
+    @whisper_helper
     async def remove(self, ctx: GIRContext):
         db_user = user_service.get_user(ctx.author.id)
         db_user.timezone = None

--- a/utils/framework/checks.py
+++ b/utils/framework/checks.py
@@ -14,11 +14,11 @@ class PermissionsFailure(discord.app_commands.AppCommandError):
 
 
 def whisper(func: discord.app_commands.Command):
-    """If the user is not a moderator and the invoked channel is not #bot-commands, send the response to the command ephemerally"""
+    """If the user is not a helper and the invoked channel is not #bot-commands, send the response to the command ephemerally"""
 
     @functools.wraps(func)
     async def decorator(self, ctx: GIRContext, *args, **kwargs):
-        if not gatekeeper.has(ctx.guild, ctx.author, 5) and ctx.channel.id != guild_service.get_guild().channel_botspam:
+        if not gatekeeper.has(ctx.guild, ctx.author, 4) and ctx.channel.id != guild_service.get_guild().channel_botspam:
             ctx.whisper = True
         else:
             ctx.whisper = False

--- a/utils/framework/checks.py
+++ b/utils/framework/checks.py
@@ -26,6 +26,16 @@ def whisper(func: discord.app_commands.Command):
 
     return decorator
 
+def whisper_helper(func: discord.app_commands.Command):
+    @functools.wraps(func)
+    async def decorator(self, ctx: GIRContext, *args, **kwargs):
+        if not gatekeeper.has(ctx.guild, ctx.author, 5) and ctx.channel.id != guild_service.get_guild().channel_botspam:
+            ctx.whisper = True
+        else:
+            ctx.whisper = False
+        await func(self, ctx, *args, **kwargs)
+
+    return decorator
 
 def whisper_in_general(func: discord.app_commands.Command):
     """If the user is not a moderator and the invoked channel is #general, send the response to the command ephemerally"""


### PR DESCRIPTION
This PR makes some edits in terms of the permissions for the "Helper" role.
# Why?
Helpers should have more permissions compared to a normal "Member Stage 2". However, I think that helpers should have a few more permissions, mainly the `/memes` command and `/poll` command.
# How?
This PR changes permissions for `/memes` and `/poll` while also adding a few extra perms for helpers (not whispering on some commands).
